### PR TITLE
Split internal bookmarks table and change hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.100",
  "which",
@@ -1248,6 +1248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +1862,7 @@ dependencies = [
  "entities",
  "quickcheck",
  "quickcheck_macros",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]

--- a/crates/wp-html-api/Cargo.toml
+++ b/crates/wp-html-api/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 entities = { path = "../entities" }
+rustc-hash = "2.1.1"
 
 [dev-dependencies]
 divan = { version = "2.8.1", package = "codspeed-divan-compat" }

--- a/crates/wp-html-api/src/html_processor/html_token.rs
+++ b/crates/wp-html-api/src/html_processor/html_token.rs
@@ -1,9 +1,10 @@
-use std::rc::Rc;
-
 use crate::tag_processor::{NodeName, ParsingNamespace};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct HTMLToken {
+    pub(crate) is_root_node: bool,
+    pub(crate) is_context_node: bool,
+
     ///
     /// Name of bookmark corresponding to source of token in input HTML string.
     ///
@@ -15,7 +16,7 @@ pub struct HTMLToken {
     ///
     /// @var string
     ///
-    pub bookmark_name: Option<Rc<str>>,
+    pub bookmark_name: Option<u32>,
 
     /**
      * Name of node; lowercase names such as "marker" are not HTML elements.
@@ -75,16 +76,29 @@ impl HTMLToken {
     /// @param callable|null $on_destroy            Optional. Function to call when destroying token, useful for releasing the bookmark.
     ///
     pub fn new(
-        bookmark_name: Option<&str>,
+        bookmark_name: Option<u32>,
         node_name: NodeName,
         has_self_closing_flag: bool,
     ) -> Self {
         Self {
-            bookmark_name: bookmark_name.map(|s| s.into()),
-            namespace: Default::default(),
-            integration_node_type: None,
+            bookmark_name,
             node_name,
             has_self_closing_flag,
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for HTMLToken {
+    fn default() -> Self {
+        Self {
+            is_root_node: false,
+            is_context_node: false,
+            bookmark_name: None,
+            namespace: Default::default(),
+            integration_node_type: None,
+            node_name: NodeName::Token(crate::tag_processor::TokenType::Text),
+            has_self_closing_flag: false,
         }
     }
 }


### PR DESCRIPTION
- Split bookmarks into internal and external bookmarks
- Use rustc-hash for hashing internal bookmarks
- Use u32 as internal bookmark keys